### PR TITLE
Removing if statement in set_email function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ License: MIT + file LICENSE
 URL: https://github.com/ropensci/essurvey, https://ropensci.github.io/essurvey/
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Imports: 
     xml2,
     httr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,14 @@
+## essurvey 1.0.3.9999
+
+### Bug fixes
+
+* Removes an unnecessary if statement in `set_email` that didn't allow to overwrite the email once set.
+
 ## essurvey 1.0.2
 
 ### Minor changes
 
 * `show_country_rounds` checks if there are missing values and excludes them.
-
-### Bug fixes
-
-* Removes an unnecessary if statement in `set_email` that didn't allow to overwrite the email once set.
 
 ### Breaking changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
-## essurvey 1.0.3.9999
-
 ## essurvey 1.0.2
 
 ### Minor changes
 
-`show_country_rounds` checks if there are missing values and excludes them.
+* `show_country_rounds` checks if there are missing values and excludes them.
+
+### Bug fixes
+
+* Removes an unnecessary if statement in `set_email` that didn't allow to overwrite the email once set.
 
 ### Breaking changes
 

--- a/R/set_email.R
+++ b/R/set_email.R
@@ -17,9 +17,7 @@
 #' }
 #' 
 set_email <- function(ess_email) {
-  if (Sys.getenv("ESS_EMAIL") == "") {
-    Sys.setenv("ESS_EMAIL" = ess_email)
-  }
+  Sys.setenv("ESS_EMAIL" = ess_email)
 }
 
 get_email <- function() {

--- a/tests/testthat/test-set_email.R
+++ b/tests/testthat/test-set_email.R
@@ -1,0 +1,12 @@
+context("test-set_email")
+
+# Test for set_email
+test_that("test email is correctly set", {
+  set_email(ess_email = "test@test.com")
+  expect_equal(Sys.getenv("ESS_EMAIL"), "test@test.com")
+})
+
+test_that("check if email can be overwritten", {
+  set_email(ess_email = "test_bis@test.com")
+  expect_false(is(Sys.getenv("ESS_EMAIL"), "test@test.com"))
+})

--- a/tests/testthat/test-set_email.R
+++ b/tests/testthat/test-set_email.R
@@ -1,12 +1,9 @@
 context("test-set_email")
 
 # Test for set_email
-test_that("test email is correctly set", {
+test_that("test email is correctly set and can be overwritten", {
   set_email(ess_email = "test@test.com")
   expect_equal(Sys.getenv("ESS_EMAIL"), "test@test.com")
-})
-
-test_that("check if email can be overwritten", {
   set_email(ess_email = "test_bis@test.com")
-  expect_false(is(Sys.getenv("ESS_EMAIL"), "test@test.com"))
+  expect_equal(Sys.getenv("ESS_EMAIL"), "test_bis@test.com")
 })


### PR DESCRIPTION
This PR fixes an issue in `set_email()` function by removing a unnecessary if statement that didn't allow to overwrite the email once set.